### PR TITLE
fix: Add stencil func to `Stencil testing` summary

### DIFF
--- a/src/nv2apretty/subprocessors/common_shader_state.py
+++ b/src/nv2apretty/subprocessors/common_shader_state.py
@@ -43,6 +43,7 @@ from nv2apretty.extracted_data import (
     NV097_SET_SHADER_OTHER_STAGE_INPUT,
     NV097_SET_SHADER_STAGE_PROGRAM,
     NV097_SET_SHADOW_DEPTH_FUNC,
+    NV097_SET_STENCIL_FUNC,
     NV097_SET_STENCIL_FUNC_MASK,
     NV097_SET_STENCIL_FUNC_REF,
     NV097_SET_STENCIL_MASK,
@@ -124,6 +125,7 @@ class CommonShaderState(PipelineState):
                 NV097_SET_SHADER_OTHER_STAGE_INPUT,
                 NV097_SET_SHADER_STAGE_PROGRAM,
                 NV097_SET_SHADOW_DEPTH_FUNC,
+                NV097_SET_STENCIL_FUNC,
                 NV097_SET_STENCIL_FUNC_MASK,
                 NV097_SET_STENCIL_FUNC_REF,
                 NV097_SET_STENCIL_MASK,
@@ -303,6 +305,7 @@ class CommonShaderState(PipelineState):
 
         def render_stencil_state(suffix: str, _: int):
             ret.append(f"\tStencil testing:{suffix}")
+            ret.append(f"\t\tFunc: {self._process(NV097_SET_STENCIL_FUNC)}")
             ret.append(f"\t\tTest mask: {self._process(NV097_SET_STENCIL_FUNC_MASK)}")
             ret.append(f"\t\tRef value: {self._process(NV097_SET_STENCIL_FUNC_REF)}")
             ret.append(f"\t\tFail op: {self._process(NV097_SET_STENCIL_OP_FAIL)}")


### PR DESCRIPTION
Fixes #40

### Summary
This PR addresses [Add stencil func to `Stencil testing` summary](https://github.com/abaire/nv2apretty/issues/40).

### Changes
```
 src/nv2apretty/subprocessors/common_shader_state.py | 3 +++
 1 file changed, 3 insertions(+)

```

### Testing
- Existing test suite was run after applying changes
- Manual review of diff for correctness

---
<sub>If this fix isn't quite right, please leave feedback and I'll revise it.</sub>
